### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ project status.
 Resources
 *********
 
-* Documentation: https://django-ticketoffice.readthedocs.org
+* Documentation: https://django-ticketoffice.readthedocs.io
 * PyPI page: http://pypi.python.org/pypi/django-ticketoffice
 * Code repository: https://github.com/benoitbryon/django-ticketoffice
 * Bugtracker: https://github.com/benoitbryon/django-ticketoffice/issues
@@ -78,8 +78,8 @@ Resources
 .. _`django-mail-factory`:
    https://pypi.python.org/pypi/django-mail-factory
 .. _`vision`:
-   https://django-ticketoffice.readthedocs.org/en/latest/about/vision.html
+   https://django-ticketoffice.readthedocs.io/en/latest/about/vision.html
 .. _`roadmap`:
    https://github.com/benoitbryon/django-ticketoffice/milestones
 .. _`alternatives`:
-   https://django-ticketoffice.readthedocs.org/en/latest/about/alternatives.html
+   https://django-ticketoffice.readthedocs.io/en/latest/about/alternatives.html

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 VERSION = open(os.path.join(here, 'VERSION')).read().strip()
 AUTHOR = u'Benoît Bryon'
 EMAIL = 'benoit@marmelune.net'
-URL = 'https://{name}.readthedocs.org/'.format(name=NAME)
+URL = 'https://{name}.readthedocs.io/'.format(name=NAME)
 CLASSIFIERS = ['Development Status :: 3 - Alpha',
                'License :: OSI Approved :: BSD License',
                'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
